### PR TITLE
Converted boolean into number in two places to avoid arithmetic on boolean error.

### DIFF
--- a/Forte_Cooldown/Forte_Cooldown.lua
+++ b/Forte_Cooldown/Forte_Cooldown.lua
@@ -828,7 +828,7 @@ local function CD_ScanWeaponEnchant()
     CD:CheckCooldown(FWL.WEAPON_ENCHANT_MAIN,GetTime(),0,"",FLAG_ENCHANT);
   end
   if hasOffHandEnchant then
-    CD:CheckCooldown(FWL.WEAPON_ENCHANT_OFFHAND,GetTime(),offHandExpiration*0.001,GetInventoryItemTexture("player",select(1,GetInventorySlotInfo("SecondaryHandSlot"))),FLAG_ENCHANT);
+    CD:CheckCooldown(FWL.WEAPON_ENCHANT_OFFHAND,GetTime(),offHandExpiration and 1 or 0*0.001,GetInventoryItemTexture("player",select(1,GetInventorySlotInfo("SecondaryHandSlot"))),FLAG_ENCHANT);
   else
     CD:CheckCooldown(FWL.WEAPON_ENCHANT_OFFHAND,GetTime(),0,"",FLAG_ENCHANT);
   end

--- a/Forte_Timer/Forte_Timer.lua
+++ b/Forte_Timer/Forte_Timer.lua
@@ -1321,7 +1321,7 @@ end
 local function checkWeaponEnchant(has,left,count,name,slotname)
   local index = st:find2(ENCHANT,6,name,8);
   if has then
-    left = left*0.001;
+    left = left and 1 or 0*0.001;
     local expire = GetTime()+left;
     if index then
       if --[[st[index][1] ~= expire]] abs( st[index][1]-expire ) > 0.1 or st[index][14] > NORMAL then


### PR DESCRIPTION
I've been using this addon since I found it for TBC Classic and now I got tired of having to hide all the error messages so I made a fix.

DISCLAIMER: I have never coded in LUA before and I have no idea how my fix migh affect other parts of the code. I merely concluded that the error appeared because of an arithmetic operation on a boolean, and the googled "how to convert boolean to number in lua". Works great for me but I have in no way fully tested the fix for all classes/configurations.

fixes #1