### PR TITLE
Update Options.lua (Options menu will not shown correctly)

### DIFF
--- a/Forte_Core/Options.lua
+++ b/Forte_Core/Options.lua
@@ -4710,6 +4710,7 @@ function FW:NewOptionsPanel()
   end
   obj.SetFont = function(self)
     local fo,si,fl = unpack(FW.Settings.OptionsFont);
+		fl = ""; --dirty fix
     local ss = si-2;
     local foh,sih,flh = unpack(FW.Settings.OptionsHeaderFont);
 


### PR DESCRIPTION
Options menu will not shown correctly
the fl = flags for SetFont seem not to be set anywhere for the options menu otherwise it will response in a nil error.

https://wowpedia.fandom.com/wiki/API_FontInstance_SetFont "Patch 10.0.0 (2022-10-25): The flags parameter is no longer optional." seems to be mandatory after the patch aswell